### PR TITLE
 Add support a JWT object

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ $decoded_token = jwt_decode($token, $key);
 //    [sub] => 1234567890
 // )
 print_r($decoded_token);
+
+// or would you prefer to use a static method call
+$token = \Cdoco\JWT::encode($payload, $key);
+$decoded_token = \Cdoco\JWT::decode($token, $key);
 ```
 
 ## Algorithms and Usage

--- a/jwt.php
+++ b/jwt.php
@@ -5,6 +5,8 @@ if(!extension_loaded('jwt')) {
 	dl('jwt.' . PHP_SHLIB_SUFFIX);
 }
 
+use Cdoco\JWT;
+
 $key = "example_key";
 $claims = array(
     "data" => [
@@ -17,7 +19,7 @@ $claims = array(
 );
 
 // default HS256 algorithm
-$token = jwt_encode($claims, $key);
+$token = JWT::encode($claims, $key);
 
 echo $token . PHP_EOL;
-print_r(jwt_decode($token, $key, ["aud" => ['yy'], 'leeway' => 2, "iss" => "http://example.org"]));
+print_r(JWT::decode($token, $key, ["aud" => ['yy'], 'leeway' => 2, "iss" => "http://example.org"]));

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://pear.php.net/dtd/package-2.0" xmlns:tasks="http://pear.php.net/dtd/tasks-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" packagerversion="1.4.7" version="2.0" xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0 http://pear.php.net/dtd/tasks-1.0.xsd http://pear.php.net/dtd/package-2.0 http://pear.php.net/dtd/package-2.0.xsd"> 
+ <name>jwt</name>
+ <channel>pecl.php.net</channel>
+ <summary>RFC 7519 OAuth JSON Web Token (JWT) implementation</summary>
+ <description>https://github.com/cdoco/php-jwt</description>
+ <lead>
+  <name>ZiHang Gao</name>
+  <user>cdoco</user>
+  <email>ocdoco@gmail.com</email>
+  <active>yes</active>
+ </lead>
+ <date>2018-06-15</date>
+ <time>17:40:00</time>
+ <version>
+  <release>0.2.3</release>
+  <api>0.2.3</api>
+ </version>
+ <stability>
+  <release>stable</release>
+  <api>stable</api>
+ </stability>
+ <license uri="http://www.php.net/license">PHP</license>
+ <notes>
+  - First release.
+ </notes>
+ <contents>
+  <dir name="/">
+   <file name="config.m4" role="src" />
+   <file name="php_jwt.h" role="src" />
+   <file name="openssl.c" role="src" />
+   <file name="jwt.c"     role="src" />
+   <file name="LICENSE"   role="doc" />
+   <file name="CREDITS"   role="doc" />
+   <file name="README.md" role="doc" />
+   <dir name="tests">
+    <file name="001.phpt" role="test" />
+    <file name="002.phpt" role="test" />
+    <file name="003.phpt" role="test" />
+    <file name="004.phpt" role="test" />
+    <file name="005.phpt" role="test" />
+    <file name="006.phpt" role="test" />
+    <file name="007.phpt" role="test" />
+    <file name="008.phpt" role="test" />
+    <file name="009.phpt" role="test" />
+    <file name="010.phpt" role="test" />
+    <file name="011.phpt" role="test" />
+   </dir>
+  </dir>
+ </contents>
+ <dependencies>
+  <required>
+   <php>
+    <min>7.0.0</min>
+   </php>
+   <pearinstaller>
+    <min>1.4.0</min>
+   </pearinstaller>
+  </required>
+ </dependencies>
+ <providesextension>jwt</providesextension>
+ <extsrcrelease />
+ <changelog>
+  <release>
+   <version>
+    <release>0.2.3</release>
+    <api>0.2.3</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <date>2018-06-15</date>
+   <time>17:40:00</time>
+   <license uri="http://www.php.net/license">PHP</license>
+   <notes>
+    - First release.
+   </notes>
+  </release>
+ </changelog>
+</package>

--- a/tests/012.phpt
+++ b/tests/012.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Check for jwt \Cdoco\JWT object
+--SKIPIF--
+<?php if (!extension_loaded("jwt")) print "skip"; ?>
+--FILE--
+<?php
+use Cdoco\JWT;
+
+$key = "example_key";
+$payload = array(
+    "data" => [
+        "name" => "ZiHang Gao",
+        "admin" => true
+    ],
+    "iss" => "http://example.org",
+    "sub" => "1234567890",
+);
+
+$token = JWT::encode($payload, $key);
+
+echo $token . PHP_EOL;
+print_r(JWT::decode($token, $key));
+?>
+--EXPECT--
+eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7Im5hbWUiOiJaaUhhbmcgR2FvIiwiYWRtaW4iOnRydWV9LCJpc3MiOiJodHRwOlwvXC9leGFtcGxlLm9yZyIsInN1YiI6IjEyMzQ1Njc4OTAifQ.6BafFmznKQOPVO9q5f5GgTVadITh2KmdUlJBF8UHOxo
+Array
+(
+    [data] => Array
+        (
+            [name] => ZiHang Gao
+            [admin] => 1
+        )
+
+    [iss] => http://example.org
+    [sub] => 1234567890
+)


### PR DESCRIPTION
Support calls the method object .

```php
use Cdoco\JWT;

$key = "example-hmac-key";
$payload = ["data" => "data"];

$token = JWT::encode($payload, $key);
$decoded_token = JWT::decode($token, $key);
```