### PR TITLE
Consistently use short array syntax in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ $ make && make install
 
 ```php
 $key = "example-hmac-key";
-$payload = array(
+$payload = [
     "data" => [
         "name" => "ZiHang Gao",
         "admin" => true
     ],
     "iss" => "http://example.org",
     "sub" => "1234567890",
-);
+];
 
 // default HS256 algorithm
 $token = jwt_encode($payload, $key);


### PR DESCRIPTION
The readme mixed between the long form (`array()`) and short form (`[]`) even within the same data structure. This PR updates to only use the short form.